### PR TITLE
Update OARS metadata for chat

### DIFF
--- a/io.github.srb2.rphys.metainfo.xml
+++ b/io.github.srb2.rphys.metainfo.xml
@@ -63,7 +63,7 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
-    <content_attribute id="social-chat">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
in the SRB2 reveries metadata, it shows that it has no chat functionality
<img width="1300" height="403" alt="Screenshot 2026-04-05 at 9 59 53 AM" src="https://github.com/user-attachments/assets/363c0348-bd57-41f5-a434-9707ac8963f0" />
but in game it has a chat function just like SRB2, and since moderation depends on the server host (it isn't handled by the game) it was given a 13+ rating.

thank you